### PR TITLE
added captive_portal to esp32-s3-box-3

### DIFF
--- a/esp32-s3-box-3/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3/esp32-s3-box-3.yaml
@@ -98,6 +98,8 @@ wifi:
   on_disconnect:
     - script.execute: draw_display
 
+captive_portal:
+
 button:
   - platform: factory_reset
     id: factory_reset_btn


### PR DESCRIPTION
Added captive_portal to provide a fallback for users to configure wifi via AP in the event that improv_serial: should fail