### PR TITLE
Update m5stack-atom-echo.yaml: i2s_mode rename to channel

### DIFF
--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -48,7 +48,7 @@ speaker:
     id: echo_speaker
     i2s_dout_pin: GPIO22
     dac_type: external
-    mode: mono
+    channel: mono
 
 voice_assistant:
   id: va


### PR DESCRIPTION
The latest release of esphome renamed i2s variable mode to channel. Don't know if any other configs are affected, just trying to get this fixed for the atom asap.