### PR TITLE
Update configs for ESPHome 2024.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         esp32-s3-box-lite/esp32-s3-box-lite.factory.yaml
         esp32-s3-box-3/esp32-s3-box-3.factory.yaml
         m5stack-atom-echo/m5stack-atom-echo.factory.yaml
-      esphome-version: 2024.7.3
+      esphome-version: 2024.9.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/esp32-s3-box-3/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3/esp32-s3-box-3.yaml
@@ -34,7 +34,7 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
-  min_version: 2024.7.0
+  min_version: 2024.9.0
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio

--- a/esp32-s3-box-lite/esp32-s3-box-lite.yaml
+++ b/esp32-s3-box-lite/esp32-s3-box-lite.yaml
@@ -34,7 +34,7 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
-  min_version: 2024.7.0
+  min_version: 2024.9.0
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio

--- a/esp32-s3-box/esp32-s3-box.yaml
+++ b/esp32-s3-box/esp32-s3-box.yaml
@@ -34,7 +34,7 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
-  min_version: 2024.7.0
+  min_version: 2024.9.0
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -48,7 +48,7 @@ speaker:
     id: echo_speaker
     i2s_dout_pin: GPIO22
     dac_type: external
-    mode: mono
+    channel: mono
 
 voice_assistant:
   id: va

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -7,7 +7,7 @@ esphome:
   name: ${name}
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
-  min_version: 2024.7.1
+  min_version: 2024.9.0
 
 esp32:
   board: m5stack-atom


### PR DESCRIPTION
There was a breaking change on the `i2s_speaker` `speaker` which removed the unused `mode` field and added a new `channel` field.

Cherry picks and closes #17 as that PR cannot be merged by itself without more changes.