### PR TITLE
define esp-idf version to 4.4.8 

### DIFF
--- a/esp32-s3-box-3/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3/esp32-s3-box-3.yaml
@@ -57,6 +57,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
+    version: 4.4.8
+    platform_version: 5.4.0
     sdkconfig_options:
       CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"
       CONFIG_ESP32S3_DATA_CACHE_64KB: "y"

--- a/esp32-s3-box-lite/esp32-s3-box-lite.yaml
+++ b/esp32-s3-box-lite/esp32-s3-box-lite.yaml
@@ -57,6 +57,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
+    version: 4.4.8
+    platform_version: 5.4.0
     sdkconfig_options:
       CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"
       CONFIG_ESP32S3_DATA_CACHE_64KB: "y"

--- a/esp32-s3-box/esp32-s3-box.yaml
+++ b/esp32-s3-box/esp32-s3-box.yaml
@@ -57,6 +57,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
+    version: 4.4.8
+    platform_version: 5.4.0
     sdkconfig_options:
       CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"
       CONFIG_ESP32S3_DATA_CACHE_64KB: "y"

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -13,6 +13,8 @@ esp32:
   board: m5stack-atom
   framework:
     type: esp-idf
+    version: 4.4.8
+    platform_version: 5.4.0
 
 logger:
 api:


### PR DESCRIPTION
change esp-idf version to 4.4.8 in order for existing voice firmware to continue work after update to ESPHome 2024.12.0 until such  time that a permanent solution is in place to replace esp_adf