### PR TITLE
[M5 Echo] Use new media player to support announcements

### DIFF
--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -56,7 +56,7 @@ speaker:
 
 media_player:
   - platform: speaker
-    name: "Media Player"
+    name: None
     id: echo_media_player
     announcement_pipeline:
       speaker: echo_speaker

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -56,7 +56,7 @@ speaker:
 
 media_player:
   - platform: speaker
-    name: "Speaker Media Player"
+    name: "Media Player"
     id: echo_media_player
     announcement_pipeline:
       speaker: echo_speaker

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -7,7 +7,7 @@ esphome:
   name: ${name}
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
-  min_version: 2024.9.0
+  min_version: 2025.2.0
 
 esp32:
   board: m5stack-atom
@@ -50,16 +50,52 @@ speaker:
     id: echo_speaker
     i2s_dout_pin: GPIO22
     dac_type: external
-    channel: mono
+    bits_per_sample: 32bit
+    channel: right
+    buffer_duration: 60ms
+
+media_player:
+  - platform: speaker
+    name: "Speaker Media Player"
+    id: echo_media_player
+    announcement_pipeline:
+      speaker: echo_speaker
+      format: WAV
+    codec_support_enabled: false
+    buffer_size: 6000
+    files:
+      - id: timer_finished_wave_file
+        file: https://github.com/esphome/wake-word-voice-assistants/raw/main/sounds/timer_finished.wav
+    on_announcement:
+      - if:
+          condition:
+            - microphone.is_capturing:
+          then:
+            - if:
+                condition:
+                  lambda: return id(wake_word_engine_location).state == "On device";
+                then:
+                  - micro_wake_word.stop:
+                else:
+                  - voice_assistant.stop:
+            - script.execute: reset_led
+      - light.turn_on:
+          id: led
+          blue: 100%
+          red: 0%
+          green: 0%
+          brightness: 100%
+          effect: none
+    on_idle:
+      - script.execute: start_wake_word
 
 voice_assistant:
   id: va
   microphone: echo_microphone
-  speaker: echo_speaker
+  media_player: echo_media_player
   noise_suppression_level: 2
   auto_gain: 31dBFS
   volume_multiplier: 2.0
-  vad_threshold: 3
   on_listening:
     - light.turn_on:
         id: led
@@ -84,22 +120,7 @@ voice_assistant:
         effect: none
   on_end:
     - delay: 100ms
-    - voice_assistant.stop:
-    - wait_until:
-        not:
-          voice_assistant.is_running:
-    - wait_until:
-        not:
-          switch.is_on: timer_ringing
-    - if:
-        condition:
-          lambda: return id(wake_word_engine_location).state == "On device";
-        then:
-          - micro_wake_word.start:
-          - script.execute: reset_led
-        else:
-          - voice_assistant.start_continuous:
-          - script.execute: reset_led
+    - script.execute: start_wake_word
   on_error:
     - light.turn_on:
         id: led
@@ -112,24 +133,17 @@ voice_assistant:
     - script.execute: reset_led
   on_client_connected:
     - delay: 2s  # Give the api server time to settle
-    - if:
-        condition:
-          lambda: return id(wake_word_engine_location).state == "On device";
-        then:
-          - micro_wake_word.start:
-        else:
-          - voice_assistant.start_continuous:
-          - script.execute: reset_led
+    - script.execute: start_wake_word
   on_client_disconnected:
     - voice_assistant.stop:
     - micro_wake_word.stop:
   on_timer_finished:
     - voice_assistant.stop:
     - micro_wake_word.stop:
-    - switch.turn_on: timer_ringing
     - wait_until:
         not:
           microphone.is_capturing:
+    - switch.turn_on: timer_ringing
     - light.turn_on:
         id: led
         red: 0%
@@ -137,26 +151,10 @@ voice_assistant:
         blue: 0%
         brightness: 100%
         effect: "Fast Pulse"
-    - while:
-        condition:
-          switch.is_on: timer_ringing
-        then:
-          - lambda: id(echo_speaker).play(id(timer_finished_wave_file), sizeof(id(timer_finished_wave_file)));
-          - delay: 1s
     - wait_until:
-        not:
-          speaker.is_playing:
+        - switch.is_off: timer_ringing
     - light.turn_off: led
     - switch.turn_off: timer_ringing
-    - if:
-        condition:
-          lambda: return id(wake_word_engine_location).state == "On device";
-        then:
-          - micro_wake_word.start:
-          - script.execute: reset_led
-        else:
-          - voice_assistant.start_continuous:
-          - script.execute: reset_led
 
 binary_sensor:
   # button does the following:
@@ -181,23 +179,7 @@ binary_sensor:
               then:
                 - switch.turn_off: timer_ringing
               else:
-                - if:
-                    condition:
-                      lambda: return id(wake_word_engine_location).state == "On device";
-                    then:
-                      - voice_assistant.stop
-                      - micro_wake_word.stop:
-                      - delay: 1s
-                      - script.execute: reset_led
-                      - script.wait: reset_led
-                      - micro_wake_word.start:
-                    else:
-                      - if:
-                          condition: voice_assistant.is_running
-                          then:
-                            - voice_assistant.stop:
-                            - script.execute: reset_led
-                      - voice_assistant.start_continuous:
+                - script.execute: start_wake_word
       - timing:
           - ON for at least 10s
         then:
@@ -259,6 +241,29 @@ script:
                       effect: none
                 else:
                   - light.turn_off: led
+  - id: start_wake_word
+    then:
+      - wait_until:
+          and:
+            - media_player.is_idle:
+            - speaker.is_stopped:
+      - if:
+          condition:
+            lambda: return id(wake_word_engine_location).state == "On device";
+          then:
+            - voice_assistant.stop
+            - micro_wake_word.stop:
+            - delay: 1s
+            - script.execute: reset_led
+            - script.wait: reset_led
+            - micro_wake_word.start:
+          else:
+            - if:
+                condition: voice_assistant.is_running
+                then:
+                  - voice_assistant.stop:
+                  - script.execute: reset_led
+            - voice_assistant.start_continuous:
 
 switch:
   - platform: template
@@ -274,9 +279,31 @@ switch:
   - platform: template
     id: timer_ringing
     optimistic: true
-    internal: true
     restore_mode: ALWAYS_OFF
+    on_turn_off:
+      # Turn off the repeat mode and disable the pause between playlist items
+      - lambda: |-
+              id(echo_media_player)
+                ->make_call()
+                .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_REPEAT_OFF)
+                .set_announcement(true)
+                .perform();
+              id(echo_media_player)->set_playlist_delay_ms(speaker::AudioPipelineType::ANNOUNCEMENT, 0);
+      # Stop playing the alarm
+      - media_player.stop:
+          announcement: true
     on_turn_on:
+      # Turn on the repeat mode and pause for 1000 ms between playlist items/repeats
+      - lambda: |-
+            id(echo_media_player)
+              ->make_call()
+              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_REPEAT_ONE)
+              .set_announcement(true)
+              .perform();
+            id(echo_media_player)->set_playlist_delay_ms(speaker::AudioPipelineType::ANNOUNCEMENT, 1000);
+      - media_player.speaker.play_on_device_media_file:
+          media_file: timer_finished_wave_file
+          announcement: true
       - delay: 15min
       - switch.turn_off: timer_ringing
 
@@ -308,21 +335,6 @@ select:
             - voice_assistant.stop
             - delay: 500ms
             - micro_wake_word.start
-
-external_components:
-  - source: github://pr#5230
-    components:
-      - esp_adf
-    refresh: 0s
-  - source: github://jesserockz/esphome-components
-    components: [file]
-    refresh: 0s
-
-esp_adf:
-
-file:
-  - id: timer_finished_wave_file
-    file: https://github.com/esphome/wake-word-voice-assistants/raw/main/sounds/timer_finished.wav
 
 micro_wake_word:
   on_wake_word_detected:


### PR DESCRIPTION
Uses the new speaker media player in ESPHome 2025.2 for handling the voice assistants audio output. It still is built with esp-idf 4.4.8 because the PDM microphone doesn't seem to work on 5.1.5.

The media player is in its most basic form, as it only supports wav files. Buffers are kept small to conserve memory. The timer takes advantage of the new media player's repeat one mode for the timer beep, but it currently requires a lambda to set.

Closes #48 (uses the new media player code to play the timer finished sound)
Closes #54 (updated voice_assistant component uses the HA wizard for creating a voice assistant)
Closes #59 (uses the correct i2s_audio speaker settings for the Echo)