### PR TITLE
Add minimum volume to m5stack-atom-echo media player

### DIFF
--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -63,6 +63,7 @@ media_player:
       format: WAV
     codec_support_enabled: false
     buffer_size: 6000
+    volume_min: 0.4
     files:
       - id: timer_finished_wave_file
         file: https://github.com/esphome/wake-word-voice-assistants/raw/main/sounds/timer_finished.wav


### PR DESCRIPTION
The atom echo is almost impossible to hear under 40% volume, so it makes sense to make the minimum 40% and let it scale from there.