### PR TITLE
Modify M5 Stack ATOM ECHO to support all voice assistant features

### DIFF
--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -1,7 +1,6 @@
 substitutions:
   name: m5stack-atom-echo
   friendly_name: M5Stack Atom Echo
-  micro_wake_word_model: okay_nabu  # alexa, hey_jarvis, hey_mycroft are also supported
 
 esphome:
   name: ${name}
@@ -42,6 +41,8 @@ microphone:
     i2s_din_pin: GPIO23
     adc_type: external
     pdm: true
+    sample_rate: 16000
+
 
 speaker:
   - platform: i2s_audio
@@ -49,6 +50,7 @@ speaker:
     i2s_dout_pin: GPIO22
     dac_type: external
     bits_per_sample: 32bit
+    sample_rate: 16000
     channel: right
     buffer_duration: 60ms
 
@@ -84,11 +86,14 @@ media_player:
 
 voice_assistant:
   id: va
-  microphone: echo_microphone
+  micro_wake_word:
+  microphone: 
+    microphone: echo_microphone
+    channels: 0
+    gain_factor: 4
   media_player: echo_media_player
   noise_suppression_level: 2
   auto_gain: 31dBFS
-  volume_multiplier: 2.0
   on_listening:
     - light.turn_on:
         id: led
@@ -112,17 +117,22 @@ voice_assistant:
         brightness: 100%
         effect: none
   on_end:
+    # Handle the "nevermind" case where there is no announcement
     - wait_until:
-        - and:
-            - not:
-                voice_assistant.is_running:
-            - not:
-                speaker.is_playing:
+        condition:
+          - media_player.is_announcing:
+        timeout: 0.5s
     # Restart only mWW if enabled; streaming wake words automatically restart
     - if:
         condition:
           - lambda: return id(wake_word_engine_location).state == "On device";
         then:
+          - wait_until:
+              - and:
+                  - not:
+                      voice_assistant.is_running:
+                  - not:
+                      speaker.is_playing:
           - lambda: id(va).set_use_wake_word(false);
           - micro_wake_word.start:
     - script.execute: reset_led
@@ -354,4 +364,6 @@ micro_wake_word:
         wake_word: !lambda return wake_word;
   vad:
   models:
-    - model: ${micro_wake_word_model}
+    - model: okay_nabu
+    - model: hey_mycroft
+    - model: hey_jarvis

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -121,10 +121,7 @@ voice_assistant:
     # Restart only mWW if enabled; streaming wake words automatically restart
     - if:
         condition:
-          and:
-            - not:
-                - voice_assistant.is_running:
-            - lambda: return id(wake_word_engine_location).state == "On device";
+          - lambda: return id(wake_word_engine_location).state == "On device";
         then:
           - lambda: id(va).set_use_wake_word(false);
           - micro_wake_word.start:

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -6,10 +6,11 @@ esphome:
   name: ${name}
   name_add_mac_suffix: true
   friendly_name: ${friendly_name}
-  min_version: 2025.2.0
+  min_version: 2025.5.0
 
 esp32:
   board: m5stack-atom
+  cpu_frequency: 240MHz
   framework:
     type: esp-idf
 
@@ -87,7 +88,7 @@ media_player:
 voice_assistant:
   id: va
   micro_wake_word:
-  microphone: 
+  microphone:
     microphone: echo_microphone
     channels: 0
     gain_factor: 4

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -44,7 +44,6 @@ microphone:
     pdm: true
     sample_rate: 16000
 
-
 speaker:
   - platform: i2s_audio
     id: echo_speaker

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -43,6 +43,7 @@ microphone:
     adc_type: external
     pdm: true
     sample_rate: 16000
+    correct_dc_offset: true
 
 speaker:
   - platform: i2s_audio

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -52,7 +52,7 @@ speaker:
     dac_type: external
     bits_per_sample: 16bit
     sample_rate: 16000
-    channel: stereo
+    channel: stereo  # The Echo has poor playback audio quality when using mon audio
     buffer_duration: 60ms
 
 media_player:

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -50,9 +50,9 @@ speaker:
     id: echo_speaker
     i2s_dout_pin: GPIO22
     dac_type: external
-    bits_per_sample: 32bit
+    bits_per_sample: 16bit
     sample_rate: 16000
-    channel: right
+    channel: stereo
     buffer_duration: 60ms
 
 media_player:

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -70,14 +70,7 @@ media_player:
           condition:
             - microphone.is_capturing:
           then:
-            - if:
-                condition:
-                  lambda: return id(wake_word_engine_location).state == "On device";
-                then:
-                  - micro_wake_word.stop:
-                else:
-                  - voice_assistant.stop:
-            - script.execute: reset_led
+            - script.execute: stop_wake_word
       - light.turn_on:
           id: led
           blue: 100%
@@ -87,6 +80,7 @@ media_player:
           effect: none
     on_idle:
       - script.execute: start_wake_word
+      - script.execute: reset_led
 
 voice_assistant:
   id: va
@@ -118,8 +112,23 @@ voice_assistant:
         brightness: 100%
         effect: none
   on_end:
-    - delay: 100ms
-    - script.execute: start_wake_word
+    - wait_until:
+        - and:
+            - not:
+                voice_assistant.is_running:
+            - not:
+                speaker.is_playing:
+    # Restart only mWW if enabled; streaming wake words automatically restart
+    - if:
+        condition:
+          and:
+            - not:
+                - voice_assistant.is_running:
+            - lambda: return id(wake_word_engine_location).state == "On device";
+        then:
+          - lambda: id(va).set_use_wake_word(false);
+          - micro_wake_word.start:
+    - script.execute: reset_led
   on_error:
     - light.turn_on:
         id: led
@@ -134,11 +143,9 @@ voice_assistant:
     - delay: 2s  # Give the api server time to settle
     - script.execute: start_wake_word
   on_client_disconnected:
-    - voice_assistant.stop:
-    - micro_wake_word.stop:
+    - script.execute: stop_wake_word
   on_timer_finished:
-    - voice_assistant.stop:
-    - micro_wake_word.stop:
+    - script.execute: stop_wake_word
     - wait_until:
         not:
           microphone.is_capturing:
@@ -241,27 +248,37 @@ script:
                   - light.turn_off: led
   - id: start_wake_word
     then:
-      - wait_until:
-          and:
-            - media_player.is_idle:
-            - speaker.is_stopped:
+      - if:
+          condition:
+            and:
+              - not:
+                  - voice_assistant.is_running:
+              - lambda: return id(wake_word_engine_location).state == "On device";
+          then:
+            - lambda: id(va).set_use_wake_word(false);
+            - micro_wake_word.start:
+      - if:
+          condition:
+            and:
+              - not:
+                  - voice_assistant.is_running:
+              - lambda: return id(wake_word_engine_location).state == "In Home Assistant";
+          then:
+            - lambda: id(va).set_use_wake_word(true);
+            - voice_assistant.start_continuous:
+  - id: stop_wake_word
+    then:
+      - if:
+          condition:
+            lambda: return id(wake_word_engine_location).state == "In Home Assistant";
+          then:
+            - lambda: id(va).set_use_wake_word(false);
+            - voice_assistant.stop:
       - if:
           condition:
             lambda: return id(wake_word_engine_location).state == "On device";
           then:
-            - voice_assistant.stop
             - micro_wake_word.stop:
-            - delay: 1s
-            - script.execute: reset_led
-            - script.wait: reset_led
-            - micro_wake_word.start:
-          else:
-            - if:
-                condition: voice_assistant.is_running
-                then:
-                  - voice_assistant.stop:
-                  - script.execute: reset_led
-            - voice_assistant.start_continuous:
 
 switch:
   - platform: template
@@ -321,7 +338,7 @@ select:
           condition:
             lambda: return x == "In Home Assistant";
           then:
-            - micro_wake_word.stop
+            - micro_wake_word.stop:
             - delay: 500ms
             - lambda: id(va).set_use_wake_word(true);
             - voice_assistant.start_continuous:
@@ -330,9 +347,9 @@ select:
             lambda: return x == "On device";
           then:
             - lambda: id(va).set_use_wake_word(false);
-            - voice_assistant.stop
+            - voice_assistant.stop:
             - delay: 500ms
-            - micro_wake_word.start
+            - micro_wake_word.start:
 
 micro_wake_word:
   on_wake_word_detected:


### PR DESCRIPTION
Start and continue conversations need special care, especially since the Echo doesn't support duplex audio. This PR makes changes to avoid stopping the voice assistant or starting microWakeWord in the middle of a start/continue conversation.

Updates the yaml to no longer compile with esp-idf v4.4, as the ``i2s_audio`` driver will be updated to correctly work on IDF5 with ESPHome 2025.5.0.

ESPhome 2025.5.0 will support configuring on-device wake words through the HA interface (including via the wizard). Three wake word models are included by default on the device: "Okay Nabu", "Hey Mycroft", and "Hey Jarvis". Only "Okay Nabu" will be activated by default.

Closes https://github.com/esphome/issues/issues/7025