### PR TITLE
Build firmware with ESPHome 2025.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         esp32-s3-box-lite/esp32-s3-box-lite.factory.yaml
         esp32-s3-box-3/esp32-s3-box-3.factory.yaml
         m5stack-atom-echo/m5stack-atom-echo.factory.yaml
-      esphome-version: 2025.4.1
+      esphome-version: 2025.5.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -13,8 +13,6 @@ esp32:
   board: m5stack-atom
   framework:
     type: esp-idf
-    version: 4.4.8
-    platform_version: 5.4.0
 
 logger:
 api:
@@ -197,7 +195,6 @@ light:
     chipset: SK6812
     num_leds: 1
     rgb_order: grb
-    rmt_channel: 0
     effects:
       - pulse:
           name: "Slow Pulse"


### PR DESCRIPTION
Needed to bump the idf version on the Echo to get it to build. Note that the mic on the Echo doesn't work without the changes in #99 