### PR TITLE
Attempt to build minimal atom echo factory firmware

### DIFF
--- a/.github/workflows/build-minimal.yml
+++ b/.github/workflows/build-minimal.yml
@@ -1,0 +1,46 @@
+name: Build minimal
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-firmware:
+    name: Build Firmware
+    uses: esphome/workflows/.github/workflows/build.yml@2025.4.0
+    with:
+      files: |
+        m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
+      esphome-version: 2025.5.0
+      release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
+      release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
+      release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+
+  upload-to-release:
+    name: Upload to Release
+    runs-on: ubuntu-latest
+    needs:
+      - build-firmware
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4.3.0
+        with:
+          path: files
+
+      - name: Copy file to output
+        run: |-
+          mkdir output
+          version="${{ github.event.release.tag_name }}"
+          cd "files/m5stack-atom-echo/$version"
+          cp m5stack-atom-echo-esp32.factory.bin ../../../output/m5stack-atom-echo.minimal.factory.bin
+          md5sum m5stack-atom-echo-esp32.factory.bin | head -c 32 > ../../../output/m5stack-atom-echo.minimal.factory.bin.md5
+
+      - name: Upload files to release
+        uses: softprops/action-gh-release@v2.2.2
+        with:
+          files: output/*
+          tag_name: ${{ github.event.release.tag_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
         esp32-s3-box-lite/esp32-s3-box-lite.factory.yaml
         esp32-s3-box-3/esp32-s3-box-3.factory.yaml
         m5stack-atom-echo/m5stack-atom-echo.factory.yaml
-        m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
       esphome-version: 2025.5.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
@@ -29,6 +28,7 @@ jobs:
   build-minimal-firmware:
     name: Build Minimal Firmware
     uses: esphome/workflows/.github/workflows/build.yml@2025.4.0
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     with:
       files: |
         m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
@@ -54,7 +54,6 @@ jobs:
     uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.4.0
     needs:
       - build-firmware
-      - build-minimal-firmware
     with:
       version: ${{ github.event.release.tag_name }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
 
   build-minimal-firmware:
-    name: Build Minimal Firmware
+    name: Build Atom Echo Minimal Firmware
     uses: esphome/workflows/.github/workflows/build.yml@2025.4.0
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,19 @@ jobs:
         esp32-s3-box-lite/esp32-s3-box-lite.factory.yaml
         esp32-s3-box-3/esp32-s3-box-3.factory.yaml
         m5stack-atom-echo/m5stack-atom-echo.factory.yaml
+        m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
+      esphome-version: 2025.5.0
+      release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
+      release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
+      release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+
+  build-minimal-firmware:
+    name: Build Minimal Firmware
+    uses: esphome/workflows/.github/workflows/build.yml@2025.4.0
+    with:
+      files: |
+        m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
+      combined-name: m5stack-atom-echo-minimal
       esphome-version: 2025.5.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
@@ -41,6 +54,7 @@ jobs:
     uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.4.0
     needs:
       - build-firmware
+      - build-minimal-firmware
     with:
       version: ${{ github.event.release.tag_name }}
 

--- a/m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
@@ -5,7 +5,7 @@ esphome:
   name: m5stack-atom-echo
   project:
     name: m5stack.atom-echo-wake-word-voice-assistant
-    version: 25.0.0 # This firmware is a first step and devices should be OTA updated to the latest firmware on first use
+    version: 25.0.0  # This firmware is a first step and devices should be OTA updated to the latest firmware on first use
 
 ota:
   - platform: http_request

--- a/m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
@@ -1,0 +1,69 @@
+packages:
+  m5stack-atom-echo: !include m5stack-atom-echo.yaml
+
+esphome:
+  name: m5stack-atom-echo
+  project:
+    name: m5stack.atom-echo-wake-word-voice-assistant
+    version: 25.0.0 # This firmware is a first step and devices should be OTA updated to the latest firmware on first use
+
+ota:
+  - platform: http_request
+    id: ota_http_request
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://firmware.esphome.io/wake-word-voice-assistant/m5stack-atom-echo/manifest.json
+
+http_request:
+  timeout: 10s
+  watchdog_timeout: 15s
+
+dashboard_import:
+  package_import_url: github://esphome/wake-word-voice-assistants/m5stack-atom-echo/m5stack-atom-echo.yaml@main
+
+improv_serial:
+
+esp32_improv:
+  authorizer: echo_button
+
+wifi:
+  on_connect:
+    - component.update: update_http_request
+    - delay: 2s
+    - ble.disable:
+
+# The below is removed to make this binary smaller
+
+binary_sensor:
+  - id: !extend echo_button
+    on_multi_click: !remove
+    on_press:
+      - delay: 10s
+      - if:
+          condition:
+            binary_sensor.is_on: echo_button
+          then:
+            - button.press: factory_reset_btn
+media_player:
+  - id: !extend echo_media_player
+    files: !remove
+    on_announcement: !remove
+    on_idle: !remove
+
+script: !remove
+
+micro_wake_word: !remove
+select: !remove
+switch: !remove
+voice_assistant:
+  on_listening: !remove
+  on_stt_vad_end: !remove
+  on_tts_start: !remove
+  on_end: !remove
+  on_error: !remove
+  on_client_connected: !remove
+  on_client_disconnected: !remove
+  on_timer_finished: !remove

--- a/m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
@@ -59,6 +59,7 @@ micro_wake_word: !remove
 select: !remove
 switch: !remove
 voice_assistant:
+  micro_wake_word: !remove
   on_listening: !remove
   on_stt_vad_end: !remove
   on_tts_start: !remove


### PR DESCRIPTION
This builds a minimal firmware and pushes the binary to the gh release alongside the other binaries. It does not push to r2 or have a manifest, purely a factory bin file for manual flashing that includes `esp32_improv` (BLE)

The version is always set to 25.0.0, and references the main manifest so it will always have an update available