### PR TITLE
Fix display when using continued conversation with LLM

### DIFF
--- a/esp32-s3-box-3/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3/esp32-s3-box-3.yaml
@@ -278,8 +278,13 @@ voice_assistant:
         then:
           - lambda: id(va).set_use_wake_word(false);
           - micro_wake_word.start:
-    - script.execute: set_idle_or_mute_phase
-    - script.execute: draw_display
+    - if:
+        condition:
+          not:
+            voice_assistant.is_running:
+        then:
+          - script.execute: set_idle_or_mute_phase
+          - script.execute: draw_display
     # Clear text sensors
     - text_sensor.template.publish:
         id: text_request

--- a/esp32-s3-box-lite/esp32-s3-box-lite.yaml
+++ b/esp32-s3-box-lite/esp32-s3-box-lite.yaml
@@ -342,8 +342,13 @@ voice_assistant:
         then:
           - lambda: id(va).set_use_wake_word(false);
           - micro_wake_word.start:
-    - script.execute: set_idle_or_mute_phase
-    - script.execute: draw_display
+    - if:
+        condition:
+          not:
+            voice_assistant.is_running:
+        then:
+          - script.execute: set_idle_or_mute_phase
+          - script.execute: draw_display
     # Clear text sensors
     - text_sensor.template.publish:
         id: text_request

--- a/esp32-s3-box/esp32-s3-box.yaml
+++ b/esp32-s3-box/esp32-s3-box.yaml
@@ -278,8 +278,13 @@ voice_assistant:
         then:
           - lambda: id(va).set_use_wake_word(false);
           - micro_wake_word.start:
-    - script.execute: set_idle_or_mute_phase
-    - script.execute: draw_display
+    - if:
+        condition:
+          not:
+            voice_assistant.is_running:
+        then:
+          - script.execute: set_idle_or_mute_phase
+          - script.execute: draw_display
     # Clear text sensors
     - text_sensor.template.publish:
         id: text_request


### PR DESCRIPTION
When using continued conversation with LLMs the display would enter the idle phase instead of the listening phase.
Note I don't have any of these devices. This is only tested on my DIY device.