### PR TITLE
Disable authorization for Atom Echo minimal factory

### DIFF
--- a/m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
@@ -27,7 +27,7 @@ dashboard_import:
 improv_serial:
 
 esp32_improv:
-  authorizer: echo_button
+  authorizer: none
 
 wifi:
   on_connect:


### PR DESCRIPTION
This is a development device distributed without instructions. It's not clear what button is used for authorization.