### PR TITLE
Fix for more flat artifact download

### DIFF
--- a/.github/workflows/build-minimal.yml
+++ b/.github/workflows/build-minimal.yml
@@ -35,9 +35,9 @@ jobs:
         run: |-
           mkdir output
           version="${{ github.event.release.tag_name }}"
-          cd "files/m5stack-atom-echo/$version"
-          cp m5stack-atom-echo-esp32.factory.bin ../../../output/m5stack-atom-echo.minimal.factory.bin
-          md5sum m5stack-atom-echo-esp32.factory.bin | head -c 32 > ../../../output/m5stack-atom-echo.minimal.factory.bin.md5
+          cd "files/$version"
+          cp m5stack-atom-echo-esp32.factory.bin ../../output/m5stack-atom-echo.minimal.factory.bin
+          md5sum m5stack-atom-echo-esp32.factory.bin | head -c 32 > ../../output/m5stack-atom-echo.minimal.factory.bin.md5
 
       - name: Upload files to release
         uses: softprops/action-gh-release@v2.5.0


### PR DESCRIPTION
The downloaded artifacts no longer have the artifact name as the folder if there is only one artifact. We only have one so need to handle this.