### PR TITLE
Fix for new 2026.2.0 timers

### DIFF
--- a/esp32-s3-box-3/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3/esp32-s3-box-3.yaml
@@ -415,7 +415,7 @@ script:
           auto output_timer = *timers.begin();
           for (const auto &timer : timers) {
             if (timer.seconds_left <= output_timer.seconds_left) {
-              output_timer = iterable_timer.second;
+              output_timer = timer;
             }
           }
           id(global_first_timer) = output_timer;


### PR DESCRIPTION
Fix for: https://github.com/esphome/wake-word-voice-assistants/issues/179

Follows example from: https://github.com/esphome/esphome/pull/13857