### PR TITLE
Attenuation update

### DIFF
--- a/esp32-s3-box-lite/esp32-s3-box-lite.yaml
+++ b/esp32-s3-box-lite/esp32-s3-box-lite.yaml
@@ -100,7 +100,7 @@ sensor:
     id: front_buttons
     internal: true
     update_interval: 16ms
-    attenuation: 11db
+    attenuation: 12db
     on_value:
       - lambda: |-
           // none: 3.121


### PR DESCRIPTION
Fixes:
```
WARNING `attenuation: 11db` is deprecated, use `attenuation: 12db` instead
```