### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-minimal.yml
+++ b/.github/workflows/build-minimal.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   build-firmware:
     name: Build Firmware
-    uses: esphome/workflows/.github/workflows/build.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/build.yml@e7eee2a828517c042794a831f75310959fbf2a16  # 2025.10.0
     with:
       files: |
         m5stack-atom-echo/m5stack-atom-echo.minimal.factory.yaml
@@ -27,7 +27,7 @@ jobs:
       - build-firmware
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: files
 
@@ -40,7 +40,7 @@ jobs:
           md5sum m5stack-atom-echo-esp32.factory.bin | head -c 32 > ../../output/m5stack-atom-echo.minimal.factory.bin.md5
 
       - name: Upload files to release
-        uses: softprops/action-gh-release@v2.6.1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
           files: output/*
           tag_name: ${{ github.event.release.tag_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build-firmware:
     name: Build Firmware
-    uses: esphome/workflows/.github/workflows/build.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/build.yml@e7eee2a828517c042794a831f75310959fbf2a16  # 2025.10.0
     with:
       files: |
         esp32-s3-box/esp32-s3-box.factory.yaml
@@ -29,7 +29,7 @@ jobs:
 
   build-minimal-firmware:
     name: Build Atom Echo Minimal Firmware
-    uses: esphome/workflows/.github/workflows/build.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/build.yml@e7eee2a828517c042794a831f75310959fbf2a16  # 2025.10.0
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     with:
       files: |
@@ -45,7 +45,7 @@ jobs:
     name: Upload to R2
     needs:
       - build-firmware
-    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@e7eee2a828517c042794a831f75310959fbf2a16  # 2025.10.0
     with:
       directory: wake-word-voice-assistant
     secrets: inherit
@@ -53,7 +53,7 @@ jobs:
   upload-to-release:
     name: Upload to Release
     if: github.event_name == 'release'
-    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.8.1
+    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@b4e1d463edfdebb57f6e536e1d8627f36f9fbabc  # 2025.8.1
     needs:
       - build-firmware
     with:
@@ -62,7 +62,7 @@ jobs:
   promote-beta:
     name: Promote to Beta
     if: github.event_name == 'release'
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.8.1
+    uses: esphome/workflows/.github/workflows/promote-r2.yml@b4e1d463edfdebb57f6e536e1d8627f36f9fbabc  # 2025.8.1
     needs:
       - upload-to-r2
     with:
@@ -75,7 +75,7 @@ jobs:
   promote-prod:
     name: Promote to Production
     if: github.event_name == 'release' && github.event.release.prerelease == false
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.8.1
+    uses: esphome/workflows/.github/workflows/promote-r2.yml@b4e1d463edfdebb57f6e536e1d8627f36f9fbabc  # 2025.8.1
     needs:
       - upload-to-r2
     with:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5.0.1
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771  # v5.0.1
         with:
           pr-inactive-days: "1"
           pr-lock-reason: ""

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10.2.0
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10.2.0
         with:
           stale-issue-message: 'As there has been no activity on this issue for 30 days, I am marking it as stale. If you think this is a mistake, please comment below and I will remove the stale label.'
           close-issue-message: 'This issue has been closed due to inactivity. If you think this is a mistake, please comment below.'

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run yamllint
         run: yamllint --strict .


### PR DESCRIPTION
## Summary

Pin all GitHub Action and reusable workflow references to their full commit SHAs
instead of mutable tags or branch names.

Closes #198


## Why?

Referencing actions by tag (e.g., `actions/checkout@v4`) is convenient but
carries a supply-chain risk: tags are mutable and can be force-pushed to point
at arbitrary commits. If an action's tag is compromised, every workflow that
references it by tag will silently run the attacker's code.

Pinning to a full 40-character commit SHA (e.g.,
`actions/checkout@11bd719...`) makes the reference immutable. Even if a tag is
tampered with, workflows pinned to a SHA will continue to use the exact code
that was reviewed and trusted.

A version comment is included next to each SHA for readability
(e.g., `actions/checkout@11bd719... # v4.2.2`).

## References

- [GitHub Blog: Four tips to keep your GitHub Actions workflows secure](https://github.blog/open-source/four-tips-to-keep-your-github-actions-workflows-secure/#use-specific-action-version-tags)
- [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [GitHub Docs: Enforcing SHA pinning for actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#requiring-workflows-to-use-pinned-versions-of-actions)
