### PR TITLE
[esp32-s3-box3] use mipi_spi display instead of deprecated ili9xxx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         esp32-s3-box-lite/esp32-s3-box-lite.factory.yaml
         esp32-s3-box-3/esp32-s3-box-3.factory.yaml
         m5stack-atom-echo/m5stack-atom-echo.factory.yaml
-      esphome-version: 2026.3.2
+      esphome-version: 2026.4.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/esp32-s3-box-3/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3/esp32-s3-box-3.yaml
@@ -38,7 +38,7 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
-  min_version: 2025.5.0
+  min_version: 2026.4.0
   name_add_mac_suffix: true
   on_boot:
     priority: 600

--- a/esp32-s3-box-3/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3/esp32-s3-box-3.yaml
@@ -768,7 +768,7 @@ spi:
     mosi_pin: 6
 
 display:
-  - platform: ili9xxx
+  - platform: mipi_spi
     id: s3_box_lcd
     model: S3BOX
     invert_colors: false


### PR DESCRIPTION
Also updates the minimum ESPHome version to 2026.4.0 and builds with 2026.4.0 (closes #196)

Fixes https://github.com/esphome/esphome/issues/15784