### PR TITLE
Add id tags to wake word models

### DIFF
--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -372,7 +372,6 @@ micro_wake_word:
         wake_word: !lambda return wake_word;
   vad:
   models:
-models:
     - model: okay_nabu
       id: okay_nabu
     - model: hey_mycroft

--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -372,6 +372,10 @@ micro_wake_word:
         wake_word: !lambda return wake_word;
   vad:
   models:
+models:
     - model: okay_nabu
+      id: okay_nabu
     - model: hey_mycroft
+      id: hey_mycroft
     - model: hey_jarvis
+      id: hey_jarvis


### PR DESCRIPTION
Currently, the models in this package lack IDs. This prevents users from using the !remove tag in their own packages to exclude unused models on the M5Stack Atom Echo.