### PR TITLE
 'codec_support_enabled' is deprecated and will be removed in 2026.10.0

### DIFF
--- a/m5stack-atom-echo/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo/m5stack-atom-echo.yaml
@@ -62,7 +62,6 @@ media_player:
     announcement_pipeline:
       speaker: echo_speaker
       format: WAV
-    codec_support_enabled: false
     buffer_size: 6000
     volume_min: 0.4
     files:


### PR DESCRIPTION
WARNING 'codec_support_enabled' is deprecated and will be removed in 2026.10.0. Codec support is now automatically determined from the pipeline 'format' setting. Set format to 'NONE' to enable all codecs.