### PR TITLE
Migrate lock workflow to esphome shared workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -5,23 +5,9 @@ on:
     - cron: "0 19 * * *"
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
-
-concurrency:
-  group: lock
-
 jobs:
   lock:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771  # v5.0.1
-        with:
-          pr-inactive-days: "1"
-          pr-lock-reason: ""
-          exclude-any-pr-labels: keep-open
-
-          issue-inactive-days: "1"
-          issue-lock-reason: ""
-          exclude-any-issue-labels: keep-open
+    uses: esphome/workflows/.github/workflows/lock.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    with:
+      pr-close-days: 1
+      issue-close-days: 1


### PR DESCRIPTION
Replaces the in-repo `dessant/lock-threads` job in `.github/workflows/lock.yml` with a call to the shared `esphome/workflows` lock workflow pinned to `2026.4.1`.

The shared workflow handles `permissions:`, `concurrency:`, and the underlying lock logic itself, so this repo only needs to declare the cron / `workflow_dispatch` triggers and override the defaults where they differ. `pr-close-days` matches the shared default but is set explicitly to preserve the original intent and shield the config from any future upstream default change; `issue-close-days: 1` overrides the shared default of 7 to keep the previous 1-day behaviour.

Dependabot's existing `shared-workflows` group will keep this in sync with `build.yml` / `build-minimal.yml` on the next bump.