### PR TITLE
feat: add Espressif ESP-VoCat voice assistant configuration

### DIFF
--- a/esp-vocat/esp-vocat.factory.yaml
+++ b/esp-vocat/esp-vocat.factory.yaml
@@ -1,5 +1,13 @@
 ---
 packages:
+  # This inline package prefixes on_client_connected with a BLE wait.
+  # It must appear BEFORE the main package so ESPHome prepends it to
+  # the on_client_connected list from esp-vocat.yaml.
+  va_connected_wait_for_ble:
+    voice_assistant:
+      on_client_connected:
+        - wait_until:
+            not: ble.enabled
   esp-vocat: !include esp-vocat.yaml
 
 esphome:

--- a/esp-vocat/esp-vocat.factory.yaml
+++ b/esp-vocat/esp-vocat.factory.yaml
@@ -1,0 +1,35 @@
+---
+packages:
+  esp-vocat: !include esp-vocat.yaml
+
+esphome:
+  project:
+    name: esphome.voice-assistant
+    version: dev
+
+ota:
+  - platform: http_request
+    id: ota_http_request
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://firmware.esphome.io/wake-word-voice-assistant/esp-vocat/manifest.json
+
+http_request:
+
+dashboard_import:
+  package_import_url: github://esphome/wake-word-voice-assistants/esp-vocat/esp-vocat.yaml@main
+
+wifi:
+  on_connect:
+    - delay: 5s
+    - ble.disable:
+  on_disconnect:
+    - ble.enable:
+
+improv_serial:
+
+esp32_improv:
+  authorizer: none

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -359,8 +359,13 @@ media_player:
           indicator:
             arc_color: 0x9B59FF
     on_idle:
-      # Announcement finished: hide the speaking ring.
-      - micro_wake_word.start:
+      # Announcement finished: hide the speaking ring. Only resume wake-word
+      # detection when not muted, so a finished announcement can't un-mute.
+      - if:
+          condition:
+            switch.is_off: mute_switch
+          then:
+            - micro_wake_word.start:
       - lvgl.widget.hide: voice_ring
     announcement_pipeline:
       speaker: spk
@@ -383,7 +388,9 @@ switch:
     name: "Mute"
     id: mute_switch
     optimistic: true
-    restore_mode: RESTORE_DEFAULT_OFF
+    # Always boot unmuted so a reboot restores listening; mute is a momentary
+    # privacy action, not a state that should survive a power cycle.
+    restore_mode: ALWAYS_OFF
     on_turn_on:
       - micro_wake_word.stop:
       - lvgl.widget.show: mute_label
@@ -402,7 +409,11 @@ voice_assistant:
   auto_gain: 31dBFS
   volume_multiplier: 1.0
   on_client_connected:
-    - micro_wake_word.start:
+    - if:
+        condition:
+          switch.is_off: mute_switch
+        then:
+          - micro_wake_word.start:
   on_client_disconnected:
     - micro_wake_word.stop:
   # Green mic LED = privacy/"listening" indicator: on only while capturing the

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -55,6 +55,7 @@ captive_portal:
 audio:
   codecs:
     wav:
+    flac:
 
 # I2C bus — ES8311 DAC (0x18), ES7210 ADC (0x40), BQ27220 battery (0x55)
 i2c:
@@ -110,6 +111,11 @@ media_player:
     name: "${friendly_name}"
     volume_min: 0.0
     volume_max: 1.0
+    files:
+      - id: wake_word_triggered_sound
+        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/wake_word_triggered.flac
+      - id: error_sound
+        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_press.flac
     on_announcement:
       - micro_wake_word.stop:
     on_idle:
@@ -144,9 +150,17 @@ voice_assistant:
     - micro_wake_word.start:
   on_client_disconnected:
     - micro_wake_word.stop:
+  on_listening:
+    # Brief chime confirms wake word was heard
+    - media_player.speaker.play_on_device_media_file:
+        media_file: wake_word_triggered_sound
+        announcement: false
   on_idle:
     - micro_wake_word.start:
   on_error:
+    - media_player.speaker.play_on_device_media_file:
+        media_file: error_sound
+        announcement: true
     - micro_wake_word.start:
 
 micro_wake_word:

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -11,7 +11,7 @@ esphome:
       then:
         - lambda: |-
             // ESP-VoCat v1.2: GPIO48 enables codec power, GPIO15 enables amplifier
-            // GPIO9 (POWER_CTRL/SAM8108) must be LOW to keep device powered on
+            // GPIO9 = BSP_LCD_EN (active-LOW via SAM8108 load switch): LOW enables LCD + SD power rail
             gpio_reset_pin(GPIO_NUM_9);
             gpio_set_direction(GPIO_NUM_9, GPIO_MODE_OUTPUT);
             gpio_set_level(GPIO_NUM_9, 0);
@@ -57,10 +57,82 @@ audio:
     wav:
     flac:
 
-# I2C bus — ES8311 DAC (0x18), ES7210 ADC (0x40), BQ27220 battery (0x55)
+# QSPI bus for ST77916 circular display
+spi:
+  - id: qspi_bus
+    type: quad
+    clk_pin: GPIO18
+    data_pins: [GPIO46, GPIO13, GPIO11, GPIO12]
+
+# ST77916 360×360 QSPI display (ESP-VoCat v1.2)
+display:
+  - platform: mipi_spi
+    id: round_display
+    spi_id: qspi_bus
+    model: ESP-VOCAT
+    update_interval: never
+
+# I2C bus — ES8311 DAC (0x18), ES7210 ADC (0x40), BQ27220 battery (0x55), BMI270 IMU (0x68)
 i2c:
   sda: GPIO2
   scl: GPIO1
+
+# BMI270 6-axis IMU — temperature shown on display
+motion:
+  - platform: bmi270
+    id: imu
+    address: 0x68
+
+sensor:
+  - platform: bmi270
+    bmi270_id: imu
+    name: "IMU Temperature"
+    id: imu_temp
+    internal: true
+    on_value:
+      - lvgl.label.update:
+          id: temp_label
+          text: !lambda return str_sprintf("%.1f\xC2\xB0C", x);
+
+time:
+  - platform: homeassistant
+    id: ha_time
+    on_time_sync:
+      - lvgl.label.update:
+          id: time_label
+          text: !lambda |
+            auto t = id(ha_time).now();
+            return str_sprintf("%02d:%02d", t.hour, t.minute);
+    on_time:
+      - seconds: 0
+        then:
+          - lvgl.label.update:
+              id: time_label
+              text: !lambda |
+                auto t = id(ha_time).now();
+                return str_sprintf("%02d:%02d", t.hour, t.minute);
+
+lvgl:
+  displays:
+    - round_display
+  pages:
+    - id: clock_page
+      bg_color: 0x000000
+      widgets:
+        - label:
+            id: time_label
+            text: "--:--"
+            align: CENTER
+            y: -30
+            text_font: montserrat_48
+            text_color: 0xFFFFFF
+        - label:
+            id: temp_label
+            text: "--.-\xC2\xB0C"
+            align: CENTER
+            y: 40
+            text_font: montserrat_24
+            text_color: 0xAAAAAA
 
 # Single I2S bus shared by microphone (RX) and speaker (TX)
 i2s_audio:

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -298,7 +298,7 @@ microphone:
   - platform: i2s_audio
     id: mic
     i2s_audio_id: i2s_bus
-    i2s_din_pin: GPIO3 # I2S_DIN v1.2 (GPIO15 on v1.0)
+    i2s_din_pin: GPIO3  # I2S_DIN v1.2 (GPIO15 on v1.0)
     adc_type: external
     channel: left
     bits_per_sample: 16bit

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -10,11 +10,8 @@ esphome:
     - priority: 700
       then:
         - lambda: |-
-            // ESP-VoCat v1.2: GPIO48 enables codec power, GPIO15 enables amplifier
-            // GPIO9 = BSP_LCD_EN (active-LOW via SAM8108 load switch): LOW enables LCD + SD power rail
-            gpio_reset_pin(GPIO_NUM_9);
-            gpio_set_direction(GPIO_NUM_9, GPIO_MODE_OUTPUT);
-            gpio_set_level(GPIO_NUM_9, 0);
+            // ESP-VoCat v1.2: GPIO48 enables codec power, GPIO15 enables amplifier.
+            // (GPIO9 LCD/SD power rail is handled by the lcd_power power_supply.)
             gpio_reset_pin(GPIO_NUM_48);
             gpio_set_direction(GPIO_NUM_48, GPIO_MODE_OUTPUT);
             gpio_set_level(GPIO_NUM_48, 1);
@@ -43,6 +40,16 @@ esp32:
 psram:
   mode: octal
   speed: 80MHz
+
+# GPIO9 (BSP_LCD_EN, active-LOW via SAM8108 load switch) powers the LCD + SD rail.
+# Managed as a power_supply so it's guaranteed enabled (plus a short delay) before
+# any bus or the display initialises.
+power_supply:
+  - id: lcd_power
+    enable_on_boot: true
+    pin:
+      number: GPIO9
+      inverted: true
 
 logger:
 

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -82,7 +82,7 @@ microphone:
   - platform: i2s_audio
     id: mic
     i2s_audio_id: i2s_bus
-    i2s_din_pin: GPIO3      # I2S_DIN v1.2 (GPIO15 on v1.0)
+    i2s_din_pin: GPIO3 # I2S_DIN v1.2 (GPIO15 on v1.0)
     adc_type: external
     channel: left
     bits_per_sample: 16bit
@@ -152,6 +152,28 @@ micro_wake_word:
   on_wake_word_detected:
     - voice_assistant.start:
 
+# CST816S capacitive touch controller on the 1.85" screen
+# Tap the screen to start/stop the voice assistant (matches stock firmware behaviour)
+touchscreen:
+  - platform: cst816
+    id: touchscreen_cst816
+    interrupt_pin: GPIO10
+    skip_probe: true # CST816S may not respond to I2C until first touch
+    on_touch:
+      - if:
+          condition:
+            voice_assistant.is_running:
+          then:
+            - voice_assistant.stop:
+          else:
+            - voice_assistant.start:
+
+# Capacitive touch pads embedded in the plastic housing
+# v1.2: two-pad slider on GPIO6 + GPIO7 (swipe gesture)
+# v1.0: single button on GPIO7 only
+esp32_touch:
+  setup_mode: false
+
 binary_sensor:
   - platform: gpio
     name: "Boot Button"
@@ -165,6 +187,13 @@ binary_sensor:
       - voice_assistant.start:
     on_release:
       - voice_assistant.stop:
+
+  # Housing capacitive touch (v1.2 slider pad 1 — can be used for mute, volume, etc.)
+  - platform: esp32_touch
+    name: "Touch Pad"
+    pin: GPIO7
+    threshold: 500
+    internal: true
 
 light:
   - platform: monochromatic

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -84,6 +84,18 @@ motion:
     address: 0x68
 
 sensor:
+  - platform: bq27220
+    address: 0x55
+    update_interval: 60s
+    battery_level:
+      name: "Battery"
+    voltage:
+      name: "Battery Voltage"
+    current:
+      name: "Battery Current"
+    time_to_empty:
+      name: "Time to Empty"
+
   - platform: bmi270
     bmi270_id: imu
     name: "IMU Temperature"

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -410,13 +410,20 @@ voice_assistant:
     - light.turn_off:
         id: mic_led
     - lvgl.widget.hide: voice_ring
+    # Shared I2S bus: after an error the pipeline goes idle and wake-word capture
+    # (mic RX) restarts. Let it fully start, then stop it and let the bus settle
+    # so the speaker (TX) can play the "didn't catch that" sound without the mic
+    # and speaker contending for the bus. Stopping mww mid-startup doesn't release
+    # the bus in time, so wait it out first. The speaker's on_idle restarts
+    # wake-word detection after the sound finishes.
+    - delay: 600ms
+    - micro_wake_word.stop:
+    - delay: 250ms
     - media_player.speaker.play_on_device_media_file:
         media_file: error_sound
         announcement: true
-    - micro_wake_word.start:
   on_idle:
     - lvgl.widget.hide: voice_ring
-    - micro_wake_word.start:
 
 micro_wake_word:
   id: mww

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -1,0 +1,185 @@
+substitutions:
+  name: esp-vocat
+  friendly_name: ESP-VoCat
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendly_name}
+  min_version: 2026.6.0
+  on_boot:
+    - priority: 700
+      then:
+        - lambda: |-
+            // ESP-VoCat v1.2: GPIO48 enables codec power, GPIO15 enables amplifier
+            gpio_reset_pin(GPIO_NUM_48);
+            gpio_set_direction(GPIO_NUM_48, GPIO_MODE_OUTPUT);
+            gpio_set_level(GPIO_NUM_48, 1);
+            gpio_reset_pin(GPIO_NUM_15);
+            gpio_set_direction(GPIO_NUM_15, GPIO_MODE_OUTPUT);
+            gpio_set_level(GPIO_NUM_15, 1);
+            vTaskDelay(pdMS_TO_TICKS(50));
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  flash_size: 16MB
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"
+      CONFIG_ESP32S3_DATA_CACHE_64KB: "y"
+      CONFIG_SPIRAM_FETCH_INSTRUCTIONS: "y"
+      CONFIG_SPIRAM_RODATA: "y"
+      CONFIG_ESP32S3_INSTRUCTION_CACHE_16KB: "y"
+
+psram:
+  mode: octal
+  speed: 80MHz
+
+logger:
+
+api:
+
+ota:
+  - platform: esphome
+
+wifi:
+  ap:
+
+captive_portal:
+
+audio:
+  codecs:
+    wav:
+
+# I2C bus — ES8311 DAC (0x18), ES7210 ADC (0x40), BQ27220 battery (0x55)
+i2c:
+  sda: GPIO2
+  scl: GPIO1
+
+# Single I2S bus shared by microphone (RX) and speaker (TX)
+i2s_audio:
+  - id: i2s_bus
+    i2s_lrclk_pin: GPIO39
+    i2s_bclk_pin: GPIO40
+    i2s_mclk_pin: GPIO42
+
+# ES7210 4-channel microphone ADC
+audio_adc:
+  - platform: es7210
+    id: es7210_adc
+    bits_per_sample: 16bit
+    sample_rate: 16000
+
+# ES8311 speaker DAC (48 kHz — media player resamples TTS to this rate)
+audio_dac:
+  - platform: es8311
+    id: es8311_dac
+    bits_per_sample: 16bit
+    sample_rate: 48000
+
+microphone:
+  - platform: i2s_audio
+    id: mic
+    i2s_audio_id: i2s_bus
+    i2s_din_pin: GPIO3      # I2S_DIN v1.2 (GPIO15 on v1.0)
+    adc_type: external
+    channel: left
+    bits_per_sample: 16bit
+    sample_rate: 16000
+
+speaker:
+  - platform: i2s_audio
+    id: spk
+    i2s_audio_id: i2s_bus
+    i2s_dout_pin: GPIO41
+    dac_type: external
+    audio_dac: es8311_dac
+    bits_per_sample: 16bit
+    sample_rate: 48000
+    channel: left
+    buffer_duration: 100ms
+
+media_player:
+  - platform: speaker
+    id: speaker_mp
+    name: "${friendly_name}"
+    volume_min: 0.0
+    volume_max: 1.0
+    on_announcement:
+      - micro_wake_word.stop:
+    on_idle:
+      - micro_wake_word.start:
+    announcement_pipeline:
+      speaker: spk
+      format: FLAC
+      sample_rate: 48000
+      num_channels: 1
+
+# GPIO48 powers the ES8311/ES7210 codec pair (v1.2 only — handled in on_boot)
+switch:
+  - platform: gpio
+    name: "Codec Power"
+    id: codec_power
+    pin: GPIO48
+    restore_mode: ALWAYS_ON
+    entity_category: diagnostic
+    internal: true
+
+voice_assistant:
+  id: va
+  microphone:
+    microphone: mic
+    channels: 0
+  media_player: speaker_mp
+  micro_wake_word: mww
+  noise_suppression_level: 2
+  auto_gain: 31dBFS
+  volume_multiplier: 1.0
+  on_client_connected:
+    - micro_wake_word.start:
+  on_client_disconnected:
+    - micro_wake_word.stop:
+  on_idle:
+    - micro_wake_word.start:
+  on_error:
+    - micro_wake_word.start:
+
+micro_wake_word:
+  id: mww
+  models:
+    - model: okay_nabu
+  on_wake_word_detected:
+    - voice_assistant.start:
+
+binary_sensor:
+  - platform: gpio
+    name: "Boot Button"
+    pin:
+      number: GPIO0
+      inverted: true
+      mode:
+        input: true
+        pullup: true
+    on_press:
+      - voice_assistant.start:
+    on_release:
+      - voice_assistant.stop:
+
+light:
+  - platform: monochromatic
+    name: "Display Backlight"
+    output: backlight_output
+    default_transition_length: 0s
+    restore_mode: ALWAYS_ON
+    entity_category: config
+
+  - platform: status_led
+    name: "Status LED"
+    id: led_status
+    pin: GPIO43
+
+output:
+  - platform: ledc
+    id: backlight_output
+    pin: GPIO44

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -56,6 +56,22 @@ wifi:
 
 captive_portal:
 
+# --- Preview components: REMOVE this block once these PRs land in an ESPHome release ---
+# The ST77916 "ESP-VOCAT" display model and the bq27220 battery gauge are not yet
+# part of a stable ESPHome release. Until they merge, pull them straight from the
+# open PRs so this config builds and flashes today:
+#   - Display (mipi_spi model): https://github.com/esphome/esphome/pull/17679
+#   - Battery gauge (bq27220):  https://github.com/esphome/esphome/pull/17702
+# After both are merged and released, delete this whole `external_components:`
+# block — the components will be built in and no external source is needed.
+external_components:
+  - source: github://pr#17702
+    components: [bq27220]
+    refresh: 1h
+  - source: github://pr#17679
+    components: [mipi_spi]
+    refresh: 1h
+
 audio:
   codecs:
     wav:

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -112,6 +112,8 @@ media_player:
     volume_min: 0.0
     volume_max: 1.0
     files:
+      - id: timer_finished_sound
+        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/timer_finished.flac
       - id: error_sound
         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_press.flac
     on_announcement:
@@ -150,6 +152,10 @@ voice_assistant:
     - micro_wake_word.stop:
   on_idle:
     - micro_wake_word.start:
+  on_timer_finished:
+    - media_player.speaker.play_on_device_media_file:
+        media_file: timer_finished_sound
+        announcement: true
   on_error:
     - media_player.speaker.play_on_device_media_file:
         media_file: error_sound

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -11,6 +11,10 @@ esphome:
       then:
         - lambda: |-
             // ESP-VoCat v1.2: GPIO48 enables codec power, GPIO15 enables amplifier
+            // GPIO9 (POWER_CTRL/SAM8108) must be LOW to keep device powered on
+            gpio_reset_pin(GPIO_NUM_9);
+            gpio_set_direction(GPIO_NUM_9, GPIO_MODE_OUTPUT);
+            gpio_set_level(GPIO_NUM_9, 0);
             gpio_reset_pin(GPIO_NUM_48);
             gpio_set_direction(GPIO_NUM_48, GPIO_MODE_OUTPUT);
             gpio_set_level(GPIO_NUM_48, 1);

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -187,6 +187,10 @@ sensor:
               - lvgl.widget.hide: charge_label
     remaining_capacity:
       name: "Battery Remaining"
+    full_charge_capacity:
+      name: "Battery Full Capacity"
+    temperature:
+      name: "Battery Temperature"
     time_to_empty:
       name: "Time to Empty"
     state_of_health:

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -131,33 +131,43 @@ sensor:
             }
           }
 
-bq27220:
-  i2c_id: i2c_bus
-  address: 0x55
-  update_interval: 60s
-  battery_level:
-    name: "Battery"
-    on_value:
-      - lvgl.arc.update:
-          id: battery_arc
-          value: !lambda "return x;"
-      - lvgl.arc.update:
-          id: battery_arc
-          indicator:
-            arc_color: !lambda |-
-              if (x < 20) return lv_color_hex(0xFF3333);
-              if (x < 50) return lv_color_hex(0xFFAA00);
-              return lv_color_hex(0x33FF33);
-  voltage:
-    name: "Battery Voltage"
-  current:
-    name: "Battery Current"
-  remaining_capacity:
-    name: "Battery Remaining"
-  time_to_empty:
-    name: "Time to Empty"
-  state_of_health:
-    name: "Battery Health"
+  # BQ27220 battery fuel gauge (level drives the on-screen battery arc).
+  - platform: bq27220
+    i2c_id: i2c_bus
+    address: 0x55
+    update_interval: 60s
+    battery_level:
+      name: "Battery"
+      on_value:
+        - lvgl.arc.update:
+            id: battery_arc
+            value: !lambda "return x;"
+        - lvgl.arc.update:
+            id: battery_arc
+            indicator:
+              arc_color: !lambda |-
+                if (x < 20) return lv_color_hex(0xFF3333);
+                if (x < 50) return lv_color_hex(0xFFAA00);
+                return lv_color_hex(0x33FF33);
+    voltage:
+      name: "Battery Voltage"
+    current:
+      name: "Battery Current"
+      # Positive current = charging; toggle the on-screen charging bolt.
+      on_value:
+        - if:
+            condition:
+              lambda: "return x > 0.02;"
+            then:
+              - lvgl.widget.show: charge_label
+            else:
+              - lvgl.widget.hide: charge_label
+    remaining_capacity:
+      name: "Battery Remaining"
+    time_to_empty:
+      name: "Time to Empty"
+    state_of_health:
+      name: "Battery Health"
 
 time:
   - platform: homeassistant
@@ -245,6 +255,15 @@ lvgl:
             y: 30
             text_font: montserrat_24
             text_color: 0xAAAAAA
+        # Charging indicator (lightning bolt) shown while the battery is charging.
+        - label:
+            id: charge_label
+            text: "\uF0E7"
+            align: CENTER
+            y: 72
+            text_font: montserrat_24
+            text_color: 0x33FF33
+            hidden: true
         - label:
             id: mute_label
             text: "MUTE"

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -156,14 +156,27 @@ micro_wake_word:
   on_wake_word_detected:
     - voice_assistant.start:
 
-# CST816S capacitive touch controller on the 1.85" screen
-# Tap the screen to start/stop the voice assistant (matches stock firmware behaviour)
-touchscreen:
-  - platform: cst816
-    id: touchscreen_cst816
-    interrupt_pin: GPIO10
-    skip_probe: true # CST816S may not respond to I2C until first touch
-    on_touch:
+# CST816S touch controller — no display support in ESPHome yet, so use
+# the interrupt pin (GPIO10) directly. CST816S pulls GPIO10 LOW on touch,
+# matching the stock firmware tap-to-talk behaviour.
+#
+# Capacitive touch pads embedded in the plastic housing
+# v1.2: two-pad slider on GPIO6 + GPIO7 (swipe gesture)
+# v1.0: single button on GPIO7 only
+esp32_touch:
+  setup_mode: false
+
+binary_sensor:
+  - platform: gpio
+    name: "Screen Touch"
+    id: screen_touch
+    pin:
+      number: GPIO10
+      inverted: true
+      mode:
+        input: true
+        pullup: true
+    on_press:
       - if:
           condition:
             voice_assistant.is_running:
@@ -172,13 +185,6 @@ touchscreen:
           else:
             - voice_assistant.start:
 
-# Capacitive touch pads embedded in the plastic housing
-# v1.2: two-pad slider on GPIO6 + GPIO7 (swipe gesture)
-# v1.0: single button on GPIO7 only
-esp32_touch:
-  setup_mode: false
-
-binary_sensor:
   - platform: gpio
     name: "Boot Button"
     pin:

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -22,6 +22,10 @@ esphome:
             gpio_set_direction(GPIO_NUM_15, GPIO_MODE_OUTPUT);
             gpio_set_level(GPIO_NUM_15, 1);
             vTaskDelay(pdMS_TO_TICKS(50));
+    # Start the backlight inactivity timer after boot (dims 15s later if idle).
+    - priority: -100
+      then:
+        - script.execute: backlight_activity
 
 esp32:
   board: esp32-s3-devkitc-1
@@ -72,79 +76,183 @@ display:
     model: ESP-VOCAT
     update_interval: never
 
-# I2C bus — ES8311 DAC (0x18), ES7210 ADC (0x40), BQ27220 battery (0x55), BMI270 IMU (0x68)
+# I2C bus — ES8311 DAC (0x18), ES7210 ADC (0x40), CST816S touch (0x15), BQ27220 battery (0x55), BMI270 IMU (0x68)
 i2c:
+  id: i2c_bus
   sda: GPIO2
   scl: GPIO1
 
-# BMI270 6-axis IMU — temperature shown on display
+# CST816S capacitive touchscreen (I2C 0x15, interrupt GPIO10)
+touchscreen:
+  - platform: cst816
+    id: ts
+    i2c_id: i2c_bus
+    address: 0x15
+    interrupt_pin: GPIO10
+    skip_probe: true
+    on_touch:
+      - script.execute: backlight_activity
+
+# BMI270 6-axis IMU (acceleration + gyroscope available for tap/orientation detection)
 motion:
   - platform: bmi270
     id: imu
+    i2c_id: i2c_bus
     address: 0x68
+    update_interval: 200ms  # poll fast enough to detect movement for the UI
 
+# Gyroscope axes (internal) used to detect movement -> wake the screen.
 sensor:
-  - platform: bq27220
-    address: 0x55
-    update_interval: 60s
-    battery_level:
-      name: "Battery"
-    voltage:
-      name: "Battery Voltage"
-    current:
-      name: "Battery Current"
-    time_to_empty:
-      name: "Time to Empty"
-
-  - platform: bmi270
-    bmi270_id: imu
-    name: "IMU Temperature"
-    id: imu_temp
+  - platform: motion
+    type: angular_rate_x
+    motion_id: imu
+    id: gyro_x
+    internal: true
+  - platform: motion
+    type: angular_rate_y
+    motion_id: imu
+    id: gyro_y
+    internal: true
+  - platform: motion
+    type: angular_rate_z
+    motion_id: imu
+    id: gyro_z
     internal: true
     on_value:
-      - lvgl.label.update:
-          id: temp_label
-          text: !lambda return str_sprintf("%.1f\xC2\xB0C", x);
+      # Movement = gyroscope vector magnitude over a threshold (deg/s). Any
+      # real movement wakes the display via the backlight_activity script.
+      - lambda: |-
+          const float gx = id(gyro_x).state, gy = id(gyro_y).state, gz = id(gyro_z).state;
+          if (!std::isnan(gx) && !std::isnan(gy) && !std::isnan(gz)) {
+            const float mag = sqrtf(gx * gx + gy * gy + gz * gz);
+            if (mag > 30.0f) {  // deg/s; tune to taste
+              id(backlight_activity).execute();
+              id(motion_pulse).execute();
+            }
+          }
+
+bq27220:
+  i2c_id: i2c_bus
+  address: 0x55
+  update_interval: 60s
+  battery_level:
+    name: "Battery"
+    on_value:
+      - lvgl.arc.update:
+          id: battery_arc
+          value: !lambda "return x;"
+      - lvgl.arc.update:
+          id: battery_arc
+          indicator:
+            arc_color: !lambda |-
+              if (x < 20) return lv_color_hex(0xFF3333);
+              if (x < 50) return lv_color_hex(0xFFAA00);
+              return lv_color_hex(0x33FF33);
+  voltage:
+    name: "Battery Voltage"
+  current:
+    name: "Battery Current"
+  remaining_capacity:
+    name: "Battery Remaining"
+  time_to_empty:
+    name: "Time to Empty"
+  state_of_health:
+    name: "Battery Health"
 
 time:
   - platform: homeassistant
     id: ha_time
     on_time_sync:
-      - lvgl.label.update:
-          id: time_label
-          text: !lambda |
-            auto t = id(ha_time).now();
-            return str_sprintf("%02d:%02d", t.hour, t.minute);
+      - script.execute: update_clock
     on_time:
       - seconds: 0
         then:
-          - lvgl.label.update:
-              id: time_label
-              text: !lambda |
-                auto t = id(ha_time).now();
-                return str_sprintf("%02d:%02d", t.hour, t.minute);
+          - script.execute: update_clock
 
 lvgl:
   displays:
     - round_display
+  touchscreens:
+    - ts
   pages:
     - id: clock_page
       bg_color: 0x000000
       widgets:
+        # Battery level as a ring around the rim (color set from battery_level).
+        - arc:
+            id: battery_arc
+            align: CENTER
+            width: 352
+            height: 352
+            arc_width: 12
+            min_value: 0
+            max_value: 100
+            value: 100
+            adjustable: false
+            arc_color: 0x202020
+            indicator:
+              arc_color: 0x33FF33
+              arc_width: 12
+        # Voice-assistant state ring (inside the battery rim): hidden when idle,
+        # cyan while listening, purple while speaking.
+        - arc:
+            id: voice_ring
+            align: CENTER
+            width: 324
+            height: 324
+            arc_width: 6
+            min_value: 0
+            max_value: 100
+            value: 100
+            adjustable: false
+            start_angle: 0
+            end_angle: 360
+            hidden: true
+            arc_color: 0x000000
+            indicator:
+              arc_color: 0x33AAFF
+              arc_width: 6
+        # Motion pulse: a ripple that expands from the centre out to the rim
+        # whenever the device is moved (triggered from the gyroscope handler).
+        - arc:
+            id: pulse_ring
+            align: CENTER
+            width: 120
+            height: 120
+            arc_width: 6
+            min_value: 0
+            max_value: 100
+            value: 100
+            adjustable: false
+            start_angle: 0
+            end_angle: 360
+            hidden: true
+            arc_color: 0x000000
+            indicator:
+              arc_color: 0x66CCFF
+              arc_width: 6
         - label:
             id: time_label
             text: "--:--"
             align: CENTER
-            y: -30
+            y: -20
             text_font: montserrat_48
             text_color: 0xFFFFFF
         - label:
-            id: temp_label
-            text: "--.-\xC2\xB0C"
+            id: date_label
+            text: ""
             align: CENTER
-            y: 40
+            y: 30
             text_font: montserrat_24
             text_color: 0xAAAAAA
+        - label:
+            id: mute_label
+            text: "MUTE"
+            align: CENTER
+            y: 100
+            text_font: montserrat_24
+            text_color: 0xFF4444
+            hidden: true
 
 # Single I2S bus shared by microphone (RX) and speaker (TX)
 i2s_audio:
@@ -201,9 +309,17 @@ media_player:
       - id: error_sound
         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_press.flac
     on_announcement:
+      # Speaker is announcing (TTS response): show the purple speaking ring.
       - micro_wake_word.stop:
+      - lvgl.widget.show: voice_ring
+      - lvgl.arc.update:
+          id: voice_ring
+          indicator:
+            arc_color: 0x9B59FF
     on_idle:
+      # Announcement finished: hide the speaking ring.
       - micro_wake_word.start:
+      - lvgl.widget.hide: voice_ring
     announcement_pipeline:
       speaker: spk
       format: FLAC
@@ -220,6 +336,19 @@ switch:
     entity_category: diagnostic
     internal: true
 
+  # Mute — stops wake word detection; Touch Pad 1 (GPIO7) toggles this
+  - platform: template
+    name: "Mute"
+    id: mute_switch
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    on_turn_on:
+      - micro_wake_word.stop:
+      - lvgl.widget.show: mute_label
+    on_turn_off:
+      - micro_wake_word.start:
+      - lvgl.widget.hide: mute_label
+
 voice_assistant:
   id: va
   microphone:
@@ -234,16 +363,40 @@ voice_assistant:
     - micro_wake_word.start:
   on_client_disconnected:
     - micro_wake_word.stop:
-  on_idle:
-    - micro_wake_word.start:
+  # Green mic LED = privacy/"listening" indicator: on only while capturing the
+  # user's voice, off once the device starts speaking (TTS). Each voice event
+  # also wakes the display via the backlight_activity script.
+  on_listening:
+    - light.turn_on:
+        id: mic_led
+    - script.execute: backlight_activity
+    - lvgl.widget.show: voice_ring
+    - lvgl.arc.update:
+        id: voice_ring
+        indicator:
+          arc_color: 0x33AAFF
+  on_tts_start:
+    - light.turn_off:
+        id: mic_led
+    - script.execute: backlight_activity
+  on_end:
+    - light.turn_off:
+        id: mic_led
+    - script.execute: backlight_activity
   on_timer_finished:
     - media_player.speaker.play_on_device_media_file:
         media_file: timer_finished_sound
         announcement: true
   on_error:
+    - light.turn_off:
+        id: mic_led
+    - lvgl.widget.hide: voice_ring
     - media_player.speaker.play_on_device_media_file:
         media_file: error_sound
         announcement: true
+    - micro_wake_word.start:
+  on_idle:
+    - lvgl.widget.hide: voice_ring
     - micro_wake_word.start:
 
 micro_wake_word:
@@ -252,27 +405,22 @@ micro_wake_word:
     - model: okay_nabu
   on_wake_word_detected:
     - voice_assistant.start:
-
-# CST816S touch controller — no display support in ESPHome yet, so use
-# the interrupt pin (GPIO10) directly. CST816S pulls GPIO10 LOW on touch,
-# matching the stock firmware tap-to-talk behaviour.
-#
-# Capacitive touch pads embedded in the plastic housing
-# v1.2: two-pad slider on GPIO6 + GPIO7 (swipe gesture)
-# v1.0: single button on GPIO7 only
+# Housing capacitive touch: single pad on GPIO7 (matches stock firmware).
+# Set setup_mode: true to log raw/benchmark values if you need to retune.
 esp32_touch:
   setup_mode: false
+  # A short window keeps the counter in range; the 8192us default saturates it.
+  measurement_duration: 1ms
 
 binary_sensor:
-  - platform: gpio
+  - platform: touchscreen
     name: "Screen Touch"
     id: screen_touch
-    pin:
-      number: GPIO10
-      inverted: true
-      mode:
-        input: true
-        pullup: true
+    touchscreen_id: ts
+    x_min: 0
+    x_max: 360
+    y_min: 0
+    y_max: 360
     on_press:
       - if:
           condition:
@@ -295,27 +443,125 @@ binary_sensor:
     on_release:
       - voice_assistant.stop:
 
-  # Housing capacitive touch (v1.2 slider pad 1 — can be used for mute, volume, etc.)
+  # A short tap toggles mute. Threshold 10000: idle noise stays < ~2800, a
+  # finger press produces 4000-40000 (raise if taps are missed, lower if mute
+  # self-triggers). The electrode is on the flex at FPC1 — if unplugged the pad
+  # reads a saturated value and won't register.
   - platform: esp32_touch
     name: "Touch Pad"
+    id: housing_touch
     pin: GPIO7
-    threshold: 500
-    internal: true
+    threshold: 10000
+    on_click:
+      min_length: 50ms
+      max_length: 2s
+      then:
+        - switch.toggle: mute_switch
+        - script.execute: backlight_activity
+
+# Display backlight: full brightness on activity, dim to 15% after 15s idle.
+# Any activity (screen touch, voice interaction, pad tap, boot) restarts the timer.
+script:
+  - id: backlight_activity
+    mode: restart
+    then:
+      - light.turn_on:
+          id: display_backlight
+          brightness: 100%
+          transition_length: 0s
+      - delay: 15s
+      - light.turn_on:
+          id: display_backlight
+          brightness: 15%
+          transition_length: 1s
+
+  # Refresh the clock face: 12-hour time with AM/PM plus the date.
+  - id: update_clock
+    then:
+      - lvgl.label.update:
+          id: time_label
+          text: !lambda return id(ha_time).now().strftime("%I:%M %p");
+      - lvgl.label.update:
+          id: date_label
+          text: !lambda return id(ha_time).now().strftime("%a, %b %d");
+
+  # Motion pulse: expand + fade a ring from the centre out to the rim.
+  - id: motion_pulse
+    mode: single
+    then:
+      - lvgl.widget.update:
+          id: pulse_ring
+          hidden: false
+          opa: 100%
+          width: 120
+          height: 120
+      - delay: 60ms
+      - lvgl.widget.update:
+          id: pulse_ring
+          width: 210
+          height: 210
+          opa: 60%
+      - delay: 60ms
+      - lvgl.widget.update:
+          id: pulse_ring
+          width: 300
+          height: 300
+          opa: 30%
+      - delay: 60ms
+      - lvgl.widget.update:
+          id: pulse_ring
+          width: 352
+          height: 352
+          opa: 10%
+      - delay: 60ms
+      - lvgl.widget.update:
+          id: pulse_ring
+          hidden: true
 
 light:
   - platform: monochromatic
     name: "Display Backlight"
+    id: display_backlight
     output: backlight_output
     default_transition_length: 0s
     restore_mode: ALWAYS_ON
     entity_category: config
 
-  - platform: status_led
-    name: "Status LED"
-    id: led_status
-    pin: GPIO43
+  # Green LED_G on GPIO43 (U0TXD), active-LOW — the "listening" indicator.
+  # Using GPIO43 gives up the UART0 serial console (we log over network/USB),
+  # and the ROM bootloader briefly blinks it at boot.
+  - platform: binary
+    name: "Mic LED"
+    id: mic_led
+    output: mic_led_output
+    entity_category: config
 
 output:
   - platform: ledc
     id: backlight_output
     pin: GPIO44
+
+  - platform: gpio
+    id: mic_led_output
+    # Green LED_G is active-LOW (anode -> MCU_3V3 via R1, cathode -> GPIO43/U0TXD).
+    # inverted so the light "on" pulls the pin low = LED lit.
+    pin:
+      number: GPIO43
+      inverted: true
+
+# SD card slot — 1-bit SDIO (supports up to 32 GB microSD)
+# Waiting on ESPHome PR #17339 (sd_storage) which depends on the storage
+# architecture PRs #17272 and #17396 before it can be merged.
+# sd_mmc_card:
+#   clk_pin: GPIO16
+#   cmd_pin: GPIO17
+#   data0_pin: GPIO38
+#   mode_1bit: true
+
+# Magnetic connector UART (5 V + serial, for expansion accessories)
+# v1.2: U1RXD = GPIO4, U1TXD = GPIO5
+uart:
+  - id: magnetic_uart
+    tx_pin: GPIO5
+    rx_pin: GPIO4
+    baud_rate: 115200

--- a/esp-vocat/esp-vocat.yaml
+++ b/esp-vocat/esp-vocat.yaml
@@ -112,8 +112,6 @@ media_player:
     volume_min: 0.0
     volume_max: 1.0
     files:
-      - id: wake_word_triggered_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/wake_word_triggered.flac
       - id: error_sound
         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_press.flac
     on_announcement:
@@ -150,11 +148,6 @@ voice_assistant:
     - micro_wake_word.start:
   on_client_disconnected:
     - micro_wake_word.stop:
-  on_listening:
-    # Brief chime confirms wake word was heard
-    - media_player.speaker.play_on_device_media_file:
-        media_file: wake_word_triggered_sound
-        announcement: false
   on_idle:
     - micro_wake_word.start:
   on_error:


### PR DESCRIPTION
## ESP-VoCat Voice Assistant

Adds ESPHome voice satellite configuration for the [Espressif ESP-VoCat](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp-vocat/index.html) — an official Espressif development kit designed for voice interaction with large language models.

> **Draft status:** kept in draft until the two upstream ESPHome PRs it depends on are merged:
> - **Display** — [esphome/esphome#17679](https://github.com/esphome/esphome/pull/17679): `mipi_spi` ST77916 / `ESP-VOCAT` model
> - **Battery gauge** — [esphome/esphome#17702](https://github.com/esphome/esphome/pull/17702): `bq27220` fuel gauge component
>
> Once both land I'll drop the draft and mark this ready for review.
>
> **Want to try it now?** The config pulls both components straight from those PRs
> via an `external_components:` block, so it builds and flashes today. That block
> is clearly marked and gets removed once the components ship in a release.

### Hardware

| Component          | Chip                                                 | Interface                         | ESPHome support                 |
| ------------------ | ---------------------------------------------------- | --------------------------------- | ------------------------------- |
| MCU                | ESP32-S3-WROOM-1-N16R16VA (16 MB Flash, 16 MB PSRAM) | —                                 | ✅                              |
| Microphone ADC     | ES7210 4-channel                                     | I2C 0x40 + I2S                    | ✅                              |
| Speaker DAC        | ES8311 mono                                          | I2C 0x18 + I2S                    | ✅                              |
| Amplifier          | NS4150B 3 W Class D                                  | GPIO15 enable (v1.2)              | ✅                              |
| Touchscreen        | CST816S (1.85", 360×360)                             | I2C 0x15, INT GPIO10              | ✅ `cst816`                     |
| Housing touch pads | ESP32-S3 capacitive                                  | GPIO7 / GPIO6+7 (v1.2 slider)     | ✅ `esp32_touch`                |
| Display            | ST77916 QSPI circular 360×360                        | QSPI GPIO11-14,18,46              | ⏳ `mipi_spi` `ESP-VOCAT` (esphome/esphome#17679) |
| Battery gauge      | BQ27220                                              | I2C 0x55                          | ⏳ `bq27220` (esphome/esphome#17702) |
| IMU                | BMI270 6-axis                                        | I2C 0x68                          | ✅ `bmi270` (motion)            |
| microSD            | 1-bit SDIO                                           | CLK GPIO16, CMD GPIO17, D0 GPIO38 | ⚠️ `sd_mmc` pending upstream (commented out) |

### Pin Reference (v1.2)

| Function                         | GPIO                 |
| -------------------------------- | -------------------- |
| I2S MCLK                         | 42                   |
| I2S BCLK                         | 40                   |
| I2S WS/LRCK                      | 39                   |
| I2S DIN (mic)                    | 3 _(GPIO15 on v1.0)_ |
| I2S DOUT (speaker)               | 41                   |
| I2C SDA                          | 2                    |
| I2C SCL                          | 1                    |
| Codec power enable               | 48                   |
| Amplifier enable                 | 15 _(GPIO4 on v1.0)_ |
| Touch interrupt                  | 10                   |
| Touch pad 1 (housing)            | 7                    |
| Touch pad 2 (housing, v1.2 only) | 6                    |
| LCD backlight                    | 44                   |
| LCD QSPI CLK                     | 18                   |
| LCD QSPI CS                      | 14                   |
| LCD RST                          | 47 _(GPIO3 on v1.0)_ |
| Status LED                       | 43                   |
| Boot button                      | 0                    |
| Power button                     | 9                    |
| SD CLK                           | 16                   |
| SD CMD                           | 17                   |
| SD DATA0                         | 38                   |

### Key implementation notes

- **GPIO48 (CODEC_PWR_CTRL)** must be driven HIGH at priority 700 (before I2C at priority 600) to power the ES7210/ES8311 codec pair on v1.2 PCB.
- **GPIO15 (PA_CTRL)** enables the NS4150B amplifier (v1.2). GPIO4 on v1.0.
- **Microphone GPIO3** is the I2S data input on v1.2 (GPIO15 on v1.0).
- **CST816S** requires `skip_probe: true` as the chip may not respond to I2C until the first touch is registered.
- **Tap-to-talk** via CST816S matches stock Xiaozhi firmware behaviour — screen tap toggles voice assistant.
- **Shared I2S bus** (mic RX + speaker TX): `micro_wake_word` is stopped before the speaker plays. `on_announcement` covers TTS playback; `on_error` waits for wake-word capture to fully start and release the bus before playing the "didn't catch that" sound, so the speaker driver doesn't fail to start on the shared bus.
- **Speaker/DAC at 48 kHz**: `media_player` pipeline decodes FLAC and handles resampling from any TTS output rate (tested with Piper 22050 Hz).
- **BMI270 IMU** drives a motion-wake feature: gyroscope movement wakes the display and triggers a ripple animation on the clock face.
- After first flash, set `select.esp_vocat_wake_word` to `okay_nabu` in the HA device page.

### Tested on

- ESP-VoCat v1.2, ESPHome 2026.6.4, Home Assistant 2026.7

